### PR TITLE
feat(UST-6D8C): adiciona nome do contêiner nas instruções do Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ PORT?=8000
 INIT?=uvicorn ${API_MODULE_MAIN}:app --host $(HOST) --port $(PORT)
 DOCKER_IMAGE_NAME=pc/preco
 DOCKERFILE_PATH=./devtools/docker/Dockerfile
+CONTAINER_NAME?=pc-preco
 
 clean:
 	@find . -name "*.pyc" | xargs rm -rf
@@ -99,10 +100,10 @@ docker-build:
 	docker build -f $(DOCKERFILE_PATH) -t $(DOCKER_IMAGE_NAME) .
 
 docker-run:
-	docker run --rm -e ENV=dev -p 8000:8000 $(DOCKER_IMAGE_NAME)
+	docker run --rm --name $(CONTAINER_NAME) -e ENV=dev -p 8000:8000 $(DOCKER_IMAGE_NAME)
 
 docker-shell:
-	docker run --rm -it -e ENV=dev $(DOCKER_IMAGE_NAME) /bin/bash
+	docker run --rm -it --name $(CONTAINER_NAME) -e ENV=dev $(DOCKER_IMAGE_NAME) /bin/bash
 
 docker-compose-sonar-up:
 	docker compose -f ./devtools/docker/docker-compose-sonar.yml up -d


### PR DESCRIPTION
Este pull request atualiza o `Makefile` para adicionar suporte à nomeação de containers Docker durante a execução. As mudanças introduzem uma nova variável `CONTAINER_NAME` e garantem seu uso consistente nos comandos Docker relevantes.

### Atualizações na gestão de containers Docker:

* Adicionada a nova variável `CONTAINER_NAME` ao `Makefile` para especificar um nome padrão para os containers Docker (`pc-preco`).
* Atualizado o alvo `docker-run` para incluir a flag `--name`, atribuindo o nome do container a partir da variável `CONTAINER_NAME`.
* Atualizado o alvo `docker-shell` para incluir a flag `--name`, também atribuindo o nome do container a partir da variável `CONTAINER_NAME`.