### PR TITLE
feat: Ajusta testes para comparar floats com pytest.approx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ PORT?=8000
 INIT?=uvicorn ${API_MODULE_MAIN}:app --host $(HOST) --port $(PORT)
 DOCKER_IMAGE_NAME=pc/preco
 DOCKERFILE_PATH=./devtools/docker/Dockerfile
+CONTAINER_NAME?=pc-preco
 
 clean:
 	@find . -name "*.pyc" | xargs rm -rf
@@ -99,10 +100,10 @@ docker-build:
 	docker build -f $(DOCKERFILE_PATH) -t $(DOCKER_IMAGE_NAME) .
 
 docker-run:
-	docker run --rm -e ENV=dev -p 8000:8000 $(DOCKER_IMAGE_NAME)
+	docker run --rm --name $(CONTAINER_NAME) -e ENV=dev -p 8000:8000 $(DOCKER_IMAGE_NAME)
 
 docker-shell:
-	docker run --rm -it -e ENV=dev $(DOCKER_IMAGE_NAME) /bin/bash
+	docker run --rm -it --name $(CONTAINER_NAME) -e ENV=dev $(DOCKER_IMAGE_NAME) /bin/bash
 
 docker-compose-sonar-up:
 	docker compose -f ./devtools/docker/docker-compose-sonar.yml up -d

--- a/tests/unit/api/test_price_router.py
+++ b/tests/unit/api/test_price_router.py
@@ -29,7 +29,7 @@ async def criar_precificacao_retorna_201(client: AsyncClient):
     payload = {"seller_id": "seller123", "sku": "sku456", "price": 100.0}
     response = await client.post("/prices", json=payload)
     assert response.status_code == status.HTTP_201_CREATED
-    assert response.json()["price"] == 100.0
+    assert response.json()["price"] == pytest.approx(100.0)
 
 
 @pytest.mark.asyncio
@@ -44,7 +44,7 @@ async def atualizar_precificacao_retorna_200(client: AsyncClient):
     payload = {"price": 150.0}
     response = await client.patch("/prices/seller123/sku456", json=payload)
     assert response.status_code == status.HTTP_200_OK
-    assert response.json()["price"] == 150.0
+    assert response.json()["price"] == pytest.approx(150.0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Este pull request atualiza as asserções dos testes no arquivo `tests/unit/api/test_price_router.py` para utilizar `pytest.approx` nas comparações de valores de ponto flutuante, garantindo maior robustez e precisão na validação dos resultados.

### O que mudou:

- O teste `criar_precificacao_retorna_201` foi modificado para usar `pytest.approx` ao comparar o campo `price` retornado na resposta, evitando falhas causadas por pequenas diferenças de representação de números de ponto flutuante.
- O teste `atualizar_precificacao_retorna_200` também passou a utilizar `pytest.approx` na comparação do campo `price`, tornando a validação mais confiável.

#### Por que essa mudança é importante?

Comparações diretas de números de ponto flutuante podem resultar em erros nos testes devido a pequenas imprecisões inerentes à representação desses números em computadores. O uso de `pytest.approx` permite que os testes aceitem pequenas variações, tornando-os mais estáveis e alinhados às boas práticas de testes em Python.